### PR TITLE
Use the official trusty vm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "phusion-open-ubuntu-14.04-amd64"
+  config.vm.box = "ubuntu/trusty64"
   config.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/latest/ubuntu-14.04-amd64-vbox.box"
   config.vm.synced_folder ".", "/home/vagrant/src/github.com/mmcgrana/pgpin"
   config.vm.provision :shell, :path => "vm.sh"


### PR DESCRIPTION
A not-particularly-flashy PR, but it moves this over to the official ubuntu trusty vm.  I figured that might reduce a small amount of confusion for anyone using pgpin as a reference application (like me!).

I have verified that pgpin works when this change is made.
